### PR TITLE
Fix issue that prevents Safari from establishing WS connection

### DIFF
--- a/javacors-runtime/src/main/java/io/mikesir87/javacors/decorators/ExposeHeadersResponseDecorator.java
+++ b/javacors-runtime/src/main/java/io/mikesir87/javacors/decorators/ExposeHeadersResponseDecorator.java
@@ -19,7 +19,9 @@ public class ExposeHeadersResponseDecorator implements ResponseDecorator {
   public void decorateResponse(ResponseHandler responseHandler,
                                CorsRequestContext requestContext,
                                CorsConfiguration configuration) {
-    if (!requestContext.isPreFlightRequest() && configuration.getExposedHeaders() != null) {
+    if (!requestContext.isPreFlightRequest() &&
+      configuration.getExposedHeaders() != null &&
+      configuration.getExposedHeaders().size() >= 1) {
       responseHandler.addHeader(HEADER_NAME, String.join(", ", configuration.getExposedHeaders()));
     }
   }


### PR DESCRIPTION
See http://stackoverflow.com/questions/34679134/websocket-safari-9-invalid-utf-8-sequence-in-header-value