### PR TITLE
Workaround for Safari when it erroneously submits empty Access-Contro…

### DIFF
--- a/javacors-runtime/src/main/java/io/mikesir87/javacors/validators/DelegatingCorsRequestContext.java
+++ b/javacors-runtime/src/main/java/io/mikesir87/javacors/validators/DelegatingCorsRequestContext.java
@@ -41,7 +41,7 @@ public class DelegatingCorsRequestContext implements CorsRequestContext {
 
   @Override
   public List<String> getRequestedHeadersAsList() {
-    return (getRequestedHeaders() != null) ?
+    return (getRequestedHeaders() != null && ! getRequestedHeaders().equals("")) ?
       Arrays.asList(getRequestedHeaders().split(", ")) : Collections.emptyList();
   }
 

--- a/javacors-runtime/src/test/java/io/mikesir87/javacors/decorators/ExposeHeadersResponseDecoratorTest.java
+++ b/javacors-runtime/src/test/java/io/mikesir87/javacors/decorators/ExposeHeadersResponseDecoratorTest.java
@@ -10,6 +10,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -53,5 +54,18 @@ public class ExposeHeadersResponseDecoratorTest {
       oneOf(responseHandler).addHeader("Access-Control-Expose-Headers", "Content-Length, Location");
     } });
     decorator.decorateResponse(responseHandler, requestContext, configuration);
+  }
+
+  @Test
+  public void testDecorateResponseWithEmptyAccessControlExposeHeaders() {
+    final List<String> headers = Collections.emptyList();
+    context.checking(new Expectations() {
+      {
+        allowing(requestContext).isPreFlightRequest();
+        will(returnValue(false));
+        allowing(configuration).getExposedHeaders();
+        will(returnValue(headers));
+      }
+    });
   }
 }

--- a/javacors-runtime/src/test/java/io/mikesir87/javacors/validators/DelegatingCorsRequestContextTest.java
+++ b/javacors-runtime/src/test/java/io/mikesir87/javacors/validators/DelegatingCorsRequestContextTest.java
@@ -1,0 +1,65 @@
+package io.mikesir87.javacors.validators;
+
+
+
+import org.jmock.auto.Mock;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jmock.Expectations;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.mikesir87.javacors.RequestContext;
+
+/**
+ * Unit test for the {@link DelegatingCorsRequestContext} class.
+ *
+ * @author Jeff Mitchell
+ */
+public class DelegatingCorsRequestContextTest {
+
+  private static final String HEADER = "POST";
+  private static final List<String> HEADERS_LIST = Arrays.asList(HEADER);
+
+  @Rule
+  public JUnitRuleMockery context = new JUnitRuleMockery();
+
+  @Mock
+  RequestContext requestContext;
+
+  private CorsRequestContext delegatingContext;
+
+  @Before
+  public void setUp() {
+    delegatingContext = new DelegatingCorsRequestContext(requestContext);
+  }
+
+  @Test
+  public void testGetRequestedHeadersAsList() {
+    context.checking(new Expectations() {
+      {
+        allowing(requestContext).getRequestedHeaders();
+        will(returnValue(HEADER));
+      }
+    });
+    assertThat(delegatingContext.getRequestedHeadersAsList(), is(HEADERS_LIST));
+  }
+
+  @Test
+  public void testGetRequestedHeadersAsListWithEmptyAccessControlRequestHeader() {
+    context.checking(new Expectations() {
+      {
+        allowing(requestContext).getRequestedHeaders();
+        will(returnValue(""));
+      }
+    });
+    assertThat(delegatingContext.getRequestedHeadersAsList(), is(Collections.emptyList()));
+  }
+}


### PR DESCRIPTION
…l-Request-Headers header

See https://bugs.webkit.org/show_bug.cgi?id=169851